### PR TITLE
libglu 9.0.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/xorg-libxdamage-feedstock/pr1/b0fdfbb
-  - https://staging.continuum.io/prefect/fs/libglvnd-feedstock/pr1/21f7edf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/xorg-libxdamage-feedstock/pr1/b0fdfbb
+  - https://staging.continuum.io/prefect/fs/libglvnd-feedstock/pr1/21f7edf

--- a/recipe/0001-Fix-opengl-gl-typo.-pkg-config-expects-gl-not-opengl.patch
+++ b/recipe/0001-Fix-opengl-gl-typo.-pkg-config-expects-gl-not-opengl.patch
@@ -1,0 +1,24 @@
+From a1b5098aa83e484d51e34fe825daa27d538add43 Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Sun, 27 Oct 2024 20:11:58 -0400
+Subject: [PATCH] Fix opengl -> gl typo. pkg-config expects gl not opengl
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 7949e30..a44575e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -16,7 +16,7 @@ endif
+ 
+ gl_provider = get_option('gl_provider')
+ if gl_provider == 'glvnd'
+-  gl_provider = 'opengl'
++  gl_provider = 'gl'
+ endif
+ dep_gl = dependency(gl_provider)
+ 
+-- 
+2.47.0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-if [[ ${HOST} =~ .*darwin.* ]]; then
-  export CPPFLAGS="${CPPFLAGS} -framework OpenGL"
-  export LDFLAGS="${LDFLAGS} -framework OpenGL"
-fi
-./configure --prefix=${PREFIX} \
-            --build=${BUILD} \
-            --host=${HOST}
-make -j${CPU_COUNT} ${VERBOSE_AT}
-make install
+mkdir -p build
+meson setup build ${MESON_ARGS} --prefix=${PREFIX}
+
+# Build and install
+meson compile -C build
+meson install -C build

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 mkdir -p build
-meson setup build ${MESON_ARGS} --prefix=${PREFIX}
+# Without ${PREFIX}/lib the library will be installed to $PREFIX/lib64.
+meson setup build ${MESON_ARGS} \
+    --prefix=${PREFIX} \
+    --libdir=${PREFIX}/lib
 
 # Build and install
 meson compile -C build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,58 @@
+{% set version = '9.0.3' %}
+
 package:
-    name: libglu
-    version: "9.0.0"
+  name: libglu
+  version: {{ version }}
 
 source:
-    url: https://archive.mesa3d.org//{{ name }}/{{ name }}-{{ version }}.tar.gz
-    md5: bbc57d4fe3bd3fb095bdbef6fcb977c4
+  url: https://gitlab.freedesktop.org/mesa/glu/-/archive/glu-{{ version }}/glu-glu-{{ version }}.tar.bz2
+  sha256: 38044ee4f255578165a54eaeb089b67fb64f7f7c0ce5fa690cd47c9df10b263c
+  patches:
+    # https://gitlab.freedesktop.org/mesa/glu/-/merge_requests/13
+    - 0001-Fix-opengl-gl-typo.-pkg-config-expects-gl-not-opengl.patch
 
 build:
   number: 0
-  skip: True  # [not linux]
+  skip: True  # [win or osx]
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ cdt('mesa-libgl-devel') }}       # [linux]
+    - {{ compiler('c') }}
+    - pkg-config                    # [unix]
+    - ninja
+    - meson
+  host:
+    - libgl-devel                        # [linux]
+    - libegl-devel                       # [linux]
+    - libdrm                             # [linux]
+    - xorg-libx11                        # [linux]
+    - xorg-xorgproto                     # [linux]
+    - xorg-libxext                       # [linux]
+    - xorg-libxdamage                    # [linux]
+    - xorg-libxxf86vm                    # [linux]
+    - libxcb                             # [linux]
+    # These dependencies are only for cos7 platforms
+    - xorg-libxau  # [linux & (ppc64le | aarch64)]
+    - xorg-libxdmcp  # [linux & (ppc64le | aarch64)]
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libGLU.a      # [not win]
-    - test -f ${PREFIX}/lib/libGLU.so     # [linux]
-    - test -f ${PREFIX}/lib/libGLU.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libGLU.a  # [not win]
+    - test -f ${PREFIX}/lib/libGLU${SHLIB_EXT}  # [not win]
+  downstreams:
+    - jasper
+    - freeglut
 
 about:
-  home: http://www.mesa3d.org/glu.html
-  license: SGI-2
+  home: https://www.mesa3d.org
+  dev_url: https://gitlab.freedesktop.org/mesa/glu
+  doc_url: https://gitlab.freedesktop.org/mesa/glu
+  license: SSGI-B-1.1 AND SGI-B-2.0 AND MIT
+  license_family: Other
   summary: Mesa OpenGL utility library (GLU).
 
 extra:
   recipe-maintainers:
     - bgruening
-    - mingwandroid
+    - hmaarrfk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,9 +40,11 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libGLU.a            # [not win]
     - test -f ${PREFIX}/lib/libGLU${SHLIB_EXT}  # [not win]
-  downstreams:
-    - jasper
-    - freeglut
+
+  # Check dowstreams if needed.
+  # downstreams:
+  #   - jasper
+  #   - freeglut
 
 about:
   home: https://www.mesa3d.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,10 @@ test:
     - test -f ${PREFIX}/lib/libGLU${SHLIB_EXT}  # [not win]
 
   # Check dowstreams if needed.
-  downstreams:
-    - jasper
-    - freeglut
-    - vtk-base 9.4.1
-    - vtk 9.4.1
+  # downstreams:
+  #   - jasper
+  #   - freeglut
+  #   - vtk-base
 
 about:
   home: https://www.mesa3d.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,8 @@ requirements:
     - xorg-libxxf86vm                    # [linux]
     - libxcb                             # [linux]
     # These dependencies are only for cos7 platforms
-    - xorg-libxau  # [linux & (ppc64le | aarch64)]
-    - xorg-libxdmcp  # [linux & (ppc64le | aarch64)]
+    - xorg-libxau  # [linux and (ppc64le or aarch64)]
+    - xorg-libxdmcp  # [linux and (ppc64le or aarch64)]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,11 @@ test:
     - test -f ${PREFIX}/lib/libGLU${SHLIB_EXT}  # [not win]
 
   # Check dowstreams if needed.
-  # downstreams:
-  #   - jasper
-  #   - freeglut
+  downstreams:
+    - jasper
+    - freeglut
+    - vtk-base 9.4.1
+    - vtk 9.4.1
 
 about:
   home: https://www.mesa3d.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ test:
 about:
   home: http://www.mesa3d.org/glu.html
   license: SGI-2
-  summary: Mesa OpenGL utility library (GLU)
+  summary: Mesa OpenGL utility library (GLU).
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,13 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or osx]
+  skip: True  # [not linux]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
-    - pkg-config                    # [unix]
+    - pkg-config                         # [unix]
     - ninja
     - meson
   host:
@@ -38,7 +38,7 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libGLU.a  # [not win]
+    - test -f ${PREFIX}/lib/libGLU.a            # [not win]
     - test -f ${PREFIX}/lib/libGLU${SHLIB_EXT}  # [not win]
   downstreams:
     - jasper
@@ -51,6 +51,7 @@ about:
   license: SSGI-B-1.1 AND SGI-B-2.0 AND MIT
   license_family: Other
   summary: Mesa OpenGL utility library (GLU).
+  description: Mesa OpenGL utility library (GLU).
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8129](https://anaconda.atlassian.net/browse/PKG-8129) 
- [Upstream repository](https://gitlab.freedesktop.org/mesa/glu)

### Explanation of changes:

- Changes are based on conda-forge recipe.
- Add a `meson` flag `-libdir=${PREFIX}/lib`, otherwise the library will be installed to `$PREFIX/lib64` and the tests fail.
- Add dev & doc urls, description, license_family
- Fix `license` name

### Notes:

- Not rebuilding but updating to **9.0.3**. 
- The `downstream` packages are tested. No issues:
```
ddb get-impact libglu 9.0.3 | jq -r -c ".[][] | [.name, .depends_on, .channel]"
	["jasper","libglu >=9.0.0,<10.0a0","main"]
	["jasper","libglu >=9.0.0,<10.0a0","main"]
	["freeglut","libglu >=9.0.0,<10.0a0","main"]
	["freeglut","libglu >=9.0.0,<10.0a0","main"]
```

[PKG-8129]: https://anaconda.atlassian.net/browse/PKG-8129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ