### PR TITLE
libglu 9.0.3: Rebuild with run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,10 @@ source:
     - 0001-Fix-opengl-gl-typo.-pkg-config-expects-gl-not-opengl.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not linux]
+  run_exports:
+    - {{ pin_subpackage('libglu') }}
 
 requirements:
   build:
@@ -45,6 +47,7 @@ test:
   # downstreams:
   #   - jasper
   #   - freeglut
+  #   - glew
   #   - vtk-base
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pkg-config                         # [unix]
     - ninja
     - meson
+    - patch
   host:
     - libgl-devel                        # [linux]
     - libegl-devel                       # [linux]
@@ -54,7 +55,8 @@ about:
   home: https://www.mesa3d.org
   dev_url: https://gitlab.freedesktop.org/mesa/glu
   doc_url: https://gitlab.freedesktop.org/mesa/glu
-  license: SSGI-B-1.1 AND SGI-B-2.0 AND MIT
+  license: SGI-B-1.1 AND SGI-B-2.0 AND MIT
+  license_url: https://docs.mesa3d.org/license.html#license-and-copyright
   license_family: Other
   summary: Mesa OpenGL utility library (GLU).
   description: Mesa OpenGL utility library (GLU).


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7763](https://anaconda.atlassian.net/browse/PKG-7763) 
- [Upstream repository](https://gitlab.freedesktop.org/mesa/glu/-/tree/glu-9.0.3?ref_type=tags)

### Explanation of changes:

- Add run_exports

### Notes:

- See an issue with the downstream package `glew` https://github.com/AnacondaRecipes/glew-feedstock/pull/6#discussion_r2114467260

[PKG-7763]: https://anaconda.atlassian.net/browse/PKG-7763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ